### PR TITLE
Change Contributions.md to refer to docs/Git Guidelines.rst.

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -4,20 +4,6 @@
 *   Travis Risner
 *   Harland Hansen
 
-(Steps to modify this file:)
-
-1.  Create a fork of the main repository into your own GitHub repositories.
-2.  Clone a copy of your repository to your local hard drive.
-3.  Create a branch to your repository.
-4.  Switch to the branch.
-5.  Modify this file by adding your name to the list above.
-6.  Commit your change to the branch with an appropriate comment.
-7.  Merge the branch back into your master branch.
-8.  Push your change back to your fork of the repository on GitHub.
-9.  Approve the change to your repository on GitHub.
-10. Create a pull request back to the main repository on GitHub.
-11. Notify Shelby so she can apply your change to the main repository.
-
-(When all contributors have followed the steps above, these
-instructions can be removed.)
+(Please refer to the document **Git Guidelines.rst** in the
+folder **docs** for instructions about how to modify this file.)
 


### PR DESCRIPTION
- Now that Git Guidelines.rst is in place, change Contributions.md
  to refer to it for instructions for changing this file.