### PR TITLE
Add coverage metrics to the project

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,8 @@
+[run]
+omit =
+    manage.py
+    FPIDjango/settings_private.py
+    FPIDjango/wsgi.py
+
+[report]
+skip_covered = True

--- a/fpiweb/tests.py
+++ b/fpiweb/tests.py
@@ -1,7 +1,0 @@
-from django.test import TestCase
-
-__author__ = '(Multiple)'
-__project__ = "Food-Pantry-Inventory"
-__creation_date__ = "04/01/2019"
-
-# Create your tests here.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = FPIDjango.settings

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = FPIDjango.settings
+addopts = --fail-on-template-vars --cov=. --cov-report html:htmlcov

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ certifi==2019.6.16
 chardet==3.0.4
 Click==7.0
 colorama==0.4.1
+coverage==4.5.4
 Django==2.2.5
 django-bootstrap4==1.0.1
 docopt==0.6.2
@@ -33,6 +34,7 @@ pyparsing==2.4.2
 pypng==0.0.20
 PyQRCode==1.2.1
 pytest==5.1.2
+pytest-cov==2.7.1
 pytest-django==3.5.1
 pytest-forked==1.0.2
 pytest-xdist==1.29.0


### PR DESCRIPTION
As a next step in enhance testing for the project, this PR adds code coverage reporting.

I'm less interested in hitting some arbitrary target level of coverage, and more interested in just seeing what's being tested and what's not.

After activating your virtual environment and running `pytest` the coverage metrics will automatically collected and an HTML report will be found in the folder `htmlcov`.