### PR TITLE
Omit test coverage on virtual environments in project directory

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,6 +3,7 @@ omit =
     manage.py
     FPIDjango/settings_private.py
     FPIDjango/wsgi.py
+    venv/*
 
 [report]
 skip_covered = True


### PR DESCRIPTION
Coverage was reporting on virtual environment files when venv is installed in the project directory.