### PR TITLE
Added managment command for creating/configuring admin group.  Create…

### DIFF
--- a/fpiweb/admin.py
+++ b/fpiweb/admin.py
@@ -23,7 +23,6 @@ __creation_date__ = "04/01/2019"
 
 # Register the models for which we want default admin pages to be built.
 admin.site.register(Activity)
-admin.site.register(BoxType)
 admin.site.register(ProductCategory)
 admin.site.register(ProductExample)
 admin.site.register(Location)
@@ -41,6 +40,15 @@ class BoxAdmin(admin.ModelAdmin):
         'product',
     )
     list_filter = ('box_type', )
+
+
+@admin.register(BoxType)
+class BoxTypeAdmin(admin.ModelAdmin):
+    list_display = (
+        'box_type_code',
+        'box_type_descr',
+        'box_type_qty',
+    )
 
 
 @admin.register(Constraints)

--- a/fpiweb/management/commands/createadmingroup.py
+++ b/fpiweb/management/commands/createadmingroup.py
@@ -1,0 +1,53 @@
+
+from django.contrib.auth.models import Group, Permission
+from django.core.management.base import BaseCommand, CommandError
+
+# Custom django-admin / manage.py command as per
+# https://docs.djangoproject.com/en/2.2/howto/custom-management-commands/
+
+
+class Command(BaseCommand):
+
+    help = """Create an admin group for the fpiweb app."""
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '-f', '--force',
+            action='store_true',
+            help="If group already exists, reset all permissions",
+        )
+        parser.add_argument(
+            'groupname',
+            metavar='GROUPNAME',
+            nargs=1,
+            type=str,
+            help="Name of group to add or edit",
+        )
+
+    def handle(self, *args, **options):
+        group_name = options.get('groupname')[0]
+        force = options.get('force', False)
+
+        group, created = Group.objects.get_or_create(name=group_name)
+        if not created:
+            if not force:
+                message = f"group {group_name} already exists and -f/--force option not specified"
+                raise CommandError(message)
+            print(f"clearing group {group_name}'s permissions")
+            group.permissions.clear()
+
+        fpiweb_permissions = Permission.objects.filter(
+            content_type__app_label='fpiweb',
+        )
+
+        box_type_permissions = fpiweb_permissions.filter(
+            content_type__model='boxtype',
+            codename__in=(
+                'add_boxtype',
+                'change_boxtype',
+                'delete_boxtype',
+                'view_boxtype',
+            )
+        )
+        for permission in box_type_permissions:
+            group.permissions.add(permission)


### PR DESCRIPTION
…d ModelAdmin for BoxType

To list commands available through `manage.py` run `manage.py` without any arguments.  Commands are listed by app.  Under `fpiweb` there is now a `createadmingroup` command.

To see how to use the `createadmingroup` command run:
`manage.py help creatadmingroup`

To create a group with adminstrative priviledges named "admin" run the following command:
`manage.py createadmingroup admin`

If the group already exists the command will just show an error and exit.  To modify an existing group use the `-f` flag as follows:
`manage.py createadmingroup -f admin`

**Warning using the `-f` option will revoke all existing permissions before adding new ones**

To make use of an admin group:
1. create a user if you don't have one in mind
2. grant the user "staff status" this allows them to log into the admin site
3. add the user to your admin group