### PR TITLE
Move documentation build out of Github Actions and into Read The Docs

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -34,29 +34,14 @@ jobs:
         python-version: '3.7.x'
     - name: Install dependencies
       run: |
-        sudo apt update
-        sudo apt install -y plantuml
         python -m pip install --upgrade pip
         pip install -r requirements.txt
     - name: Test with pytest
       run: |
         pytest --cov-report term:skip-covered --durations=6 -v --tb=line
-    - name: Build the documentation
-      run: |
-        pushd .
-        cd docs/
-        make O="-W" html
-        popd
-      if: always()
     - name: Upload Test Coverage
       uses: actions/upload-artifact@v1
       with:
         name: PytestCoverage
         path: htmlcov
-      if: always()
-    - name: Upload Documentation
-      uses: actions/upload-artifact@v1
-      with:
-        name: SphinxDocumentation
-        path: docs/build/html
       if: always()

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,6 +6,7 @@ http://www.sphinx-doc.org/en/master/config
 """
 
 import os
+import shutil
 import sys
 
 import django
@@ -37,6 +38,17 @@ BASE_DIR = os.path.dirname(parent_directory)
 
 # directory containing our Django application
 django_app_directory = os.path.join(BASE_DIR, 'fpiweb/')
+
+# Ensure private settings file exists before attempting docs build
+private_settings_module_path = os.path.join(BASE_DIR, 'FPIDjango', 'private')
+private_settings_file_path = os.path.join(private_settings_module_path, 'settings_private.py')
+if not os.path.exists(private_settings_file_path):
+    if not os.path.exists(private_settings_module_path):
+        os.mkdir(private_settings_module_path)
+    shutil.copy(
+        os.path.join(BASE_DIR, 'FPIDjango', 'settings_private.py'),
+        private_settings_file_path
+    )
 
 # Tell Sphinx to ignore Django imports
 # autodoc_mock_imports = ["django"]


### PR DESCRIPTION
- Make sure the settings_private.py file exists. If not, simply copy the template version
  into place.
- Remove doc build steps from Github Actions workflow