### PR TITLE
 Subject: #53 Modify base.html template to uses static files rather t…

### DIFF
--- a/fpiweb/templates/fpiweb/base.html
+++ b/fpiweb/templates/fpiweb/base.html
@@ -7,7 +7,7 @@
           name="viewport"
           content="width-device-width"
           initial-scale="1"
-          shrink-to-fit=no"/>
+          shrink-to-fit="no"/>
 
 {#    <!-- Bootstrap CSS -->#}
 {#    <link rel="stylesheet"#}
@@ -31,7 +31,6 @@
     <link rel="stylesheet" type="text/css" href="{% static 'bootstrap/css/bootstrap-reboot.css' %}"/>
     <link rel="stylesheet" type="text/css" href="{% static 'fpiweb/style.css' %}"/>
 
-  {% bootstrap_javascript jquery='full' %}
 </head>
 <body>
     <div class="container">
@@ -40,6 +39,9 @@
       {% block content %}
       {% endblock %}
     </div>
+
+    <script src="{% static '/fpiweb/jquery-3.3.1.min.js' %}"></script>
+    <script src="{% static '/fpiweb/popper.min.js' %}"></script>
     <script src="{% static '/bootstrap/js/bootstrap.min.js' %}"></script>
     {% block footer_javascript %}
     {% endblock %}


### PR DESCRIPTION
…han CDN urls

 What Happened: Downloaded jquery-3.3.1.min.js and popper.min.js from Bootstrap. Moved files to fpiweb/static/fpiweb directory. Added code to load above files in base.html. Removed "{% bootstrap_javascript jquery='full' %}" from Base.html so CDN files would not load from internet.
 Added " (qotation) in front of no on line 10 in base.html to fix malformed html.

 Note: Downloaded files not verified with sha-sum as I didn't find the checksums on Bootstrap site.
 Note: malformed html in index.html in lines 77, 79, 84. Problem with matching <div> tags
 Note: CDN settings for jquery-3.3.1.min.js and popper.min.js still exist in settings .py file. CDN files have been replaced with static files in base.html.