### PR TITLE
fix(Other): Rebuild requirements using newest version of pip (20.1.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+# Minimum requirements for the build system to execute.
+requires = ["setuptools", "wheel"]  # PEP 508 specifications.

--- a/requirements.txt
+++ b/requirements.txt
@@ -92,6 +92,5 @@ urllib3==1.25.9
 uWSGI==2.0.18
 uwsgitop==0.11
 wcwidth==0.1.9
-wheel==0.34.2
 wrapt==1.11.2
 zipp==3.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,6 @@ pluggy==0.13.1
 psycopg2-binary==2.8.5
 py==1.8.1
 Pygments==2.6.1
-pygraphviz==1.5
 PyMySQL==0.9.3
 pyparsing==2.4.7
 pypng==0.0.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+wheel==0.34.2
 alabaster==0.7.12
 apipkg==1.5
 appdirs==1.4.4


### PR DESCRIPTION
- This version of pip uses the legacy setup.py when wheel is not
available