### PR TITLE
06 manage product information

### DIFF
--- a/fpiweb/forms.py
+++ b/fpiweb/forms.py
@@ -1668,8 +1668,8 @@ class ProductNameForm(forms.ModelForm):
         """
         cleaned_data = super().clean()
         prod_name = cleaned_data.get('prod_name')
-        prod_cat_id = cleaned_data.get('prod_cat_id')
-        self.validate_product_fields(prod_name, prod_cat_id)
+        prod_cat = cleaned_data.get('prod_cat')
+        self.validate_product_fields(prod_name, prod_cat)
         return
 
 class ProductExampleForm(forms.ModelForm):

--- a/fpiweb/forms.py
+++ b/fpiweb/forms.py
@@ -1539,4 +1539,71 @@ class UserInfoForm(forms.Form):
 
         return
 
+
+class ProductCategoryForm(forms.ModelForm):
+    """
+    Manage Loction row details with a generic form.
+    """
+
+    class Meta:
+        """
+        Additional info to help Django provide intelligent defaults.
+        """
+        model = ProductCategory
+        fields = ['id', 'prod_cat_name', 'prod_cat_descr', ]
+
+    # following along from LocRowForm help text in models.ProductCatagory
+    # additional help text for id and prod_cat_descr
+    # not sure how its used yet
+    prod__cat_name = forms.CharField(
+        help_text=ProductCategory.prod_cat_name_help_text,
+        required=True,
+    )
+
+    @staticmethod
+    def validate_prod_cat_fields(
+            prod_cat_name: str,
+            prod_cat_descr: str,
+    ):
+        """
+        Validate the various product category record fields.
+
+        :param prod_cat_name: name of product catagory
+        :param prod_cat_descr: description of product description
+        :return: True if valid
+        """
+        max_len: int = ProductCategory.prod_cat_name_max_length
+        min_len: int = 1    # did not see min_length in ProductCategory
+        if not prod_cat_name or not (len(prod_cat_name) > 0):
+            raise ValidationError(
+                'The Product Category Name must be specified'
+            )
+        if (len(prod_cat_name) <= max_len) \
+                and \
+                (len(prod_cat_name) >= min_len):
+            ...
+        else:
+            raise ValidationError(
+                'A Product Category Name length must be between 1 and 30 characters long'
+            )
+        if not prod_cat_descr or not (len(prod_cat_descr) > 0):
+            raise ValidationError(
+                'A description of this Product Catagory must be provided'
+            )
+
+        return
+
+    def clean(self):
+        """
+        Clean and validate the data given for the constraint record.
+
+        :return:
+        """
+        cleaned_data = super().clean()
+        prod_cat_name = cleaned_data.get('prod_cat_name')
+        prod_cat_descr = cleaned_data.get('prod_cat_descr')
+        self.validate_prod_cat_fields(prod_cat_name, prod_cat_descr)
+        return
+
+
 # EOF

--- a/fpiweb/forms.py
+++ b/fpiweb/forms.py
@@ -1555,7 +1555,7 @@ class ProductCategoryForm(forms.ModelForm):
     # following along from LocRowForm help text in models.ProductCatagory
     # additional help text for id and prod_cat_descr
     # not sure how its used yet
-    prod__cat_name = forms.CharField(
+    prod_cat_name = forms.CharField(
         help_text=ProductCategory.prod_cat_name_help_text,
         required=True,
     )

--- a/fpiweb/forms.py
+++ b/fpiweb/forms.py
@@ -1639,11 +1639,12 @@ class ProductNameForm(forms.ModelForm):
         :param prod_cat_id: foreign key from product category
         :return: True if valid
         """
-        max_len: int = 30  # Product.prod_name_max_length- fix this in model later
+
+        max_len: int = Product.prod_name_max_length
         min_len: int = 1
         if not prod_name or not (len(prod_name) > 0):
             raise ValidationError(
-                'The Product Category Name must be specified'
+                'The Product name must be specified'
             )
         if (len(prod_name) <= max_len) \
                 and \
@@ -1651,7 +1652,7 @@ class ProductNameForm(forms.ModelForm):
             ...
         else:
             raise ValidationError(
-                'A Product Category Name length must be between 1 and 30 characters long'
+                'A Product name length must be between 1 and 30 characters long'
             )
         if not prod_cat:
             raise ValidationError(
@@ -1705,7 +1706,7 @@ class ProductExampleForm(forms.ModelForm):
         min_len: int = 1
         if not prod_example_name or not (len(prod_example_name) > 0):
             raise ValidationError(
-                'The Product Example Name must be specified'
+                'The Product Example name must be specified'
             )
         if (len(prod_example_name) <= max_len) \
                 and \
@@ -1713,7 +1714,7 @@ class ProductExampleForm(forms.ModelForm):
             ...
         else:
             raise ValidationError(
-                'A Product Example Name is needed)'
+                'A Product Example name is needed)'
             )
         if not product:
             raise ValidationError(

--- a/fpiweb/forms.py
+++ b/fpiweb/forms.py
@@ -53,7 +53,8 @@ from fpiweb.models import \
     LocTier, \
     Pallet, \
     Product, \
-    ProductCategory, ProductExample
+    ProductCategory, \
+    ProductExample
 from fpiweb.support.PermissionsManagement import ManageUserPermissions
 
 __author__ = '(Multiple)'

--- a/fpiweb/forms.py
+++ b/fpiweb/forms.py
@@ -1622,7 +1622,7 @@ class ProductNameForm(forms.ModelForm):
         # additional help text for id and prod_cat_descr
         # not sure how its used yet
 
-    prod_cat_name = forms.CharField(
+    prod_name = forms.CharField(
         help_text=Product.prod_name_help_text,
         required=True,
     )
@@ -1655,7 +1655,7 @@ class ProductNameForm(forms.ModelForm):
             )
         if not prod_cat:
             raise ValidationError(
-                'A (foriegn key) id of product category needs to be provided'
+                'A (foreign key) id of product category needs to be provided'
             )
 
         return
@@ -1684,7 +1684,7 @@ class ProductExampleForm(forms.ModelForm):
         model = ProductExample
         fields = ['id', 'prod_example_name', 'product', ]
 
-    product_example_name = forms.CharField(
+    prod_example_name = forms.CharField(
         help_text=ProductExample.prod_example_name_help_text,
         required=True,
     )
@@ -1730,7 +1730,7 @@ class ProductExampleForm(forms.ModelForm):
         cleaned_data = super().clean()
         product_example_name = cleaned_data.get('prod_example_name')
         product_id = cleaned_data.get('product')
-        self.validate_loc_row_fields(product_example_name, product_id)
+        self.validate_product_example_fields(product_example_name, product_id)
         return
 
 

--- a/fpiweb/forms.py
+++ b/fpiweb/forms.py
@@ -53,7 +53,7 @@ from fpiweb.models import \
     LocTier, \
     Pallet, \
     Product, \
-    ProductCategory
+    ProductCategory, ProductExample
 from fpiweb.support.PermissionsManagement import ManageUserPermissions
 
 __author__ = '(Multiple)'
@@ -1671,6 +1671,68 @@ class ProductNameForm(forms.ModelForm):
         prod_cat_id = cleaned_data.get('prod_cat_id')
         self.validate_product_fields(prod_name, prod_cat_id)
         return
+
+class ProductExampleForm(forms.ModelForm):
+    """
+    Manage Loction row details with a generic form.
+    """
+
+    class Meta:
+        """
+        Additional info to help Django provide intelligent defaults.
+        """
+        model = ProductExample
+        fields = ['id', 'prod_example_name', 'product', ]
+
+    product_example_name = forms.CharField(
+        help_text=ProductExample.prod_example_name_help_text,
+        required=True,
+    )
+
+    @staticmethod
+    def validate_product_example_fields(
+            prod_example_name: str,
+            product: int,
+    ):
+        """
+        Validate the Product Example Name and Foreigh Key Product ID
+
+        :param product_example_name: name of product example
+        :param product: foreign key from products table
+        :return: True if valid
+        """
+        max_len: int = ProductExample.prod_example_name_max_length
+        min_len: int = 1
+        if not prod_example_name or not (len(prod_example_name) > 0):
+            raise ValidationError(
+                'The Product Example Name must be specified'
+            )
+        if (len(prod_example_name) <= max_len) \
+                and \
+                (len(prod_example_name) >= min_len):
+            ...
+        else:
+            raise ValidationError(
+                'A Product Example Name is needed)'
+            )
+        if not product:
+            raise ValidationError(
+                'A Product ID is required to enter/edit a Product Example Name'
+            )
+        return
+
+    def clean(self):
+        """
+        Clean and validate the data given for the constraint record.
+
+        :return:
+        """
+        cleaned_data = super().clean()
+        product_example_name = cleaned_data.get('product_example_name')
+        product_id = cleaned_data.get('product')
+        self.validate_loc_row_fields(product_example_name, product_id)
+        return
+
 
 
 # EOF

--- a/fpiweb/forms.py
+++ b/fpiweb/forms.py
@@ -1728,7 +1728,7 @@ class ProductExampleForm(forms.ModelForm):
         :return:
         """
         cleaned_data = super().clean()
-        product_example_name = cleaned_data.get('product_example_name')
+        product_example_name = cleaned_data.get('prod_example_name')
         product_id = cleaned_data.get('product')
         self.validate_loc_row_fields(product_example_name, product_id)
         return

--- a/fpiweb/forms.py
+++ b/fpiweb/forms.py
@@ -1542,7 +1542,7 @@ class UserInfoForm(forms.Form):
 
 class ProductCategoryForm(forms.ModelForm):
     """
-    Manage Loction row details with a generic form.
+    Manage Product Category details with a generic form.
     """
 
     class Meta:
@@ -1603,6 +1603,73 @@ class ProductCategoryForm(forms.ModelForm):
         prod_cat_name = cleaned_data.get('prod_cat_name')
         prod_cat_descr = cleaned_data.get('prod_cat_descr')
         self.validate_prod_cat_fields(prod_cat_name, prod_cat_descr)
+        return
+
+# seems like the server won't fire up with a Form filled out but no Views to go with it????
+class ProductNameForm(forms.ModelForm):
+    """
+    Manage Product details with a generic form.
+    """
+
+    class Meta:
+        """
+        Additional info to help Django provide intelligent defaults.
+        """
+        model = Product
+        fields = ['id', 'prod_name', 'prod_cat', ]
+
+        # following along from LocRowForm help text in models.ProductCatagory
+        # additional help text for id and prod_cat_descr
+        # not sure how its used yet
+
+    prod_cat_name = forms.CharField(
+        help_text=Product.prod_name_help_text,
+        required=True,
+    )
+
+    @staticmethod
+    def validate_product_fields(
+            prod_name: str,
+            prod_cat: int,
+    ):
+        """
+        Validate the various product category record fields.
+
+        :param prod_cat_name: name of product
+        :param prod_cat_id: foreign key from product category
+        :return: True if valid
+        """
+        max_len: int = 30  # Product.prod_name_max_length- fix this in model later
+        min_len: int = 1
+        if not prod_name or not (len(prod_name) > 0):
+            raise ValidationError(
+                'The Product Category Name must be specified'
+            )
+        if (len(prod_name) <= max_len) \
+                and \
+                (len(prod_name) >= min_len):
+            ...
+        else:
+            raise ValidationError(
+                'A Product Category Name length must be between 1 and 30 characters long'
+            )
+        if not prod_cat:
+            raise ValidationError(
+                'A (foriegn key) id of product category needs to be provided'
+            )
+
+        return
+
+    def clean(self):
+        """
+        Clean and validate the data given for the constraint record.
+
+        :return:
+        """
+        cleaned_data = super().clean()
+        prod_name = cleaned_data.get('prod_name')
+        prod_cat_id = cleaned_data.get('prod_cat_id')
+        self.validate_product_fields(prod_name, prod_cat_id)
         return
 
 

--- a/fpiweb/models.py
+++ b/fpiweb/models.py
@@ -362,12 +362,14 @@ class ProductCategory(models.Model):
         primary_key=True,
         help_text=id_help_text,
     )
+
     """ Internal record identifier for product category. """
 
     prod_cat_name_help_text = 'Name of this product category.'
+    prod_cat_name_max_length = 30
     prod_cat_name = models.CharField(
         'Product Category Name',
-        max_length=30,
+        max_length=prod_cat_name_max_length,
         unique=True,
         help_text=prod_cat_name_help_text,
     )

--- a/fpiweb/models.py
+++ b/fpiweb/models.py
@@ -1231,10 +1231,11 @@ class ProductExample(models.Model):
     )
     """ Internal reccord identifier for product example"""
 
+    prod_example_name_max_length = 30
     prod_example_name_help_text = 'Name of example product.'
     prod_example_name = models.CharField(
         'Product Example Name',
-        max_length=30,
+        max_length=prod_example_name_max_length,
         unique=True,
         help_text=prod_example_name_help_text,
     )

--- a/fpiweb/models.py
+++ b/fpiweb/models.py
@@ -411,9 +411,10 @@ class Product(models.Model):
     """ Internal record identifier for product. """
 
     prod_name_help_text = 'Name of this product.'
+    prod_name_max_length = 30
     prod_name = models.CharField(
         'product Name',
-        max_length=30,
+        max_length=prod_name_max_length,
         unique=True,
         help_text=prod_name_help_text,
     )

--- a/fpiweb/templates/fpiweb/product_category_edit.html
+++ b/fpiweb/templates/fpiweb/product_category_edit.html
@@ -1,0 +1,66 @@
+{% extends 'fpiweb/base.html' %}
+{% load bootstrap4 %}
+
+{% block title %}
+    {% if product_category.id %}
+        Edit Product Category
+    (% else %}
+        Add Product Category
+    {% endif %}
+{% endblock %}
+
+{% block content %}
+    <div class="row">
+         <div class="col-md-4 text-center">
+            <h1 class="h1">
+                {% if prod_cat.id %}
+                    Edit Product Category
+                {% else %}
+                    Add Product Category
+                {% endif %}
+            </h1>
+         </div>
+     </div>
+
+    {% if form.non_field_errors %}
+        <div class="alert alert-danger">
+            <ul>
+                {% for error in form.non_field_errors %}
+                    <li>{{ error }}</li>
+                {% endfor %}
+            </ul>
+        </div>
+    {% endif %}
+
+    <form action="" method="post">
+        {% csrf_token %}
+        {% bootstrap_field form.prod_cat_name %}
+        {% bootstrap_field form.prod_cat_descr %}
+        {# % bootstrap_form product_category_form % #}
+        <input type="submit" value="Submit"/>
+    </form>
+
+    <br/>
+    <a href="{% url 'fpiweb:product_category_view' %}">
+        Back to row list
+    </a>
+
+    <hr class="style-one">
+
+    <h6>
+        Template: product_category_edit.html
+    </h6>
+    <h6>
+        View: ProductCategoryCreateView and ProductCategoryUpdateView
+    </h6>
+    <h6>
+        Add URL: {% url 'fpiweb:product_category_new' %}
+    </h6>
+    <h6>
+         Save URL: {% url 'fpiweb:product_category_view' %}
+    </h6>
+    <h6>
+        Return URL: {% url 'fpiweb:product_category_view' %}
+    </h6>
+
+{% endblock %}

--- a/fpiweb/templates/fpiweb/product_category_edit.html
+++ b/fpiweb/templates/fpiweb/product_category_edit.html
@@ -11,9 +11,9 @@
 
 {% block content %}
     <div class="row">
-         <div class="col-md-4 text-center">
+         <div class="col-md-12 text-center">
             <h1 class="h1">
-                {% if prod_cat.id %}
+                {% if product_category.id %}
                     Edit Product Category
                 {% else %}
                     Add Product Category
@@ -42,7 +42,7 @@
 
     <br/>
     <a href="{% url 'fpiweb:product_category_view' %}">
-        Back to row list
+        Back to Product Category list
     </a>
 
     <hr class="style-one">

--- a/fpiweb/templates/fpiweb/product_category_list.html
+++ b/fpiweb/templates/fpiweb/product_category_list.html
@@ -39,8 +39,8 @@
 
        <div class="row text-center">
         <div class="col-md-3"><strong>Product Category</strong></div>
-{#        <div class="col-md-4"><strong>Description</strong></div>#}
-        <div class="col-md-3 text-center">
+        <div class="col-md-7"><strong>Description</strong></div>
+        <div class="col-md-2 text-center">
             <strong>Edit this Product Category</strong>
         </div>
     </div>
@@ -48,9 +48,15 @@
     {% if object_list %}
         {% for product_category in object_list %}
             <div class="row text-center">
-                <div class="col-md-3">
+                <div class="col-md-3 text-left">
                     {{ product_category.prod_cat_name|safe }}
                 </div>
+
+                <div class="col-md-7 text-left">
+                    {{ product_category.prod_cat_descr }}
+                    <hr class="style-one"/>
+                </div>
+
                 <div class="col-md-2">
                     <div class="text-center">
                         <a class="btn alert-info"
@@ -63,18 +69,10 @@
                 </div>
 
             </div>
-            <div class="row text-left">
-                <div class="col-md-1">
-                    &nbsp;
-                </div>
-                <div class="col-md-11">
-                    {{ product_category.prod_cat_descr }}
-                    <hr class="style-one"/>
-                </div>
-            </div>
+
         {% endfor %}
     {% else %}
-        <p>No Product Categories are available.</p>
+        <p>No Product Categories are available. Click on the Add Button above to Add a Product Example. </p>
     {% endif %}
     <div class='row'>
         <a href="{% url 'fpiweb:maintenance' %}">

--- a/fpiweb/templates/fpiweb/product_category_list.html
+++ b/fpiweb/templates/fpiweb/product_category_list.html
@@ -40,7 +40,7 @@
        <div class="row text-center">
         <div class="col-md-3"><strong>Product Category</strong></div>
 {#        <div class="col-md-4"><strong>Description</strong></div>#}
-        <div class="col-md-2 text-center">
+        <div class="col-md-3 text-center">
             <strong>Edit this Product Category</strong>
         </div>
     </div>

--- a/fpiweb/templates/fpiweb/product_category_list.html
+++ b/fpiweb/templates/fpiweb/product_category_list.html
@@ -72,7 +72,9 @@
 
         {% endfor %}
     {% else %}
+        <div class="alert-success">
         <p>No Product Categories are available. Click on the Add Button above to Add a Product Example. </p>
+        </div>
     {% endif %}
     <div class='row'>
         <a href="{% url 'fpiweb:maintenance' %}">

--- a/fpiweb/templates/fpiweb/product_category_list.html
+++ b/fpiweb/templates/fpiweb/product_category_list.html
@@ -1,0 +1,102 @@
+{% extends 'fpiweb/base.html' %}
+
+{# Purpose: List all Product Category rows #}
+{# URL Name: product_category_view #}
+{# URL Response: GET #}
+{# Table: ProductCategory #}
+{# Form: None #}
+
+{% block title %} Product Category Row {% endblock %}
+
+{% block content %}
+    <div class="row">
+        <div class="col-md-12 text-center">
+            <h1 class="h1">
+                Product Category List
+            </h1>
+        </div>
+    </div>
+
+    <hr class="style-one"/>
+
+    <div class="row">
+        &nbsp;
+    </div>
+
+    <div class="row">
+        <div class="col-md-12 text-center">
+            <a class="btn alert-info"
+               role="button"
+               href="{% url 'fpiweb:product_category_new' %}">
+                Add a Product Category
+            </a>
+        </div>
+    </div>
+
+    <div class="row">
+        &nbsp;
+    </div>
+
+       <div class="row text-center">
+        <div class="col-md-3"><strong>Product Category</strong></div>
+{#        <div class="col-md-4"><strong>Description</strong></div>#}
+        <div class="col-md-2 text-center">
+            <strong>Edit this Product Category</strong>
+        </div>
+    </div>
+
+    {% if object_list %}
+        {% for product_category in object_list %}
+            <div class="row text-center">
+                <div class="col-md-3">
+                    {{ product_category.prod_cat_name|safe }}
+                </div>
+                <div class="col-md-2">
+                    <div class="text-center">
+                        <a class="btn alert-info"
+                           role="button"
+                           href="
+                            {% url 'fpiweb:product_category_update' pk=product_category.id %}">
+                            Edit
+                        </a>
+                    </div>
+                </div>
+
+            </div>
+            <div class="row text-left">
+                <div class="col-md-1">
+                    &nbsp;
+                </div>
+                <div class="col-md-11">
+                    {{ product_category.prod_cat_descr }}
+                    <hr class="style-one"/>
+                </div>
+            </div>
+        {% endfor %}
+    {% else %}
+        <p>No Product Categoies are available.</p>
+    {% endif %}
+    <div class='row'>
+        <a href="{% url 'fpiweb:maintenance' %}">
+            Return to system maintenance
+        </a>
+    </div>
+
+    <hr class="style-one"/>
+
+    <h6>
+        Template: product_category_list.html
+    </h6>
+    <h6>
+        View: ProductCategoryListView
+    </h6>
+    <h6>
+        Add URL: {% url 'fpiweb:product_category_new' %}
+    </h6>
+    <h6>
+        Edit URL: {% url 'fpiweb:product_category_update' pk=1 %}
+    </h6>
+
+
+{% endblock %}
+

--- a/fpiweb/templates/fpiweb/product_example_delete.html
+++ b/fpiweb/templates/fpiweb/product_example_delete.html
@@ -1,0 +1,80 @@
+{% extends 'fpiweb/base.html' %}
+
+{# Purpose - Confirm delete of a Product Example. #}
+{# URL Name - product_example_delete #}
+{# URL Response - POST #}
+{# Table - ProductExample #}
+{# Form - ProductExampleForm #}
+
+{% block title %}
+    Delete Product Example
+{% endblock %}
+
+{% block content %}
+    <div class="row">
+        <div class="col-md-12 text-center">
+            <h1 class="h1">
+                Delete Product Example
+            </h1>
+         </div>
+    </div>
+
+    <div class="row">
+        &nbsp;
+    </div>
+
+    <div class="row">
+            <div class="col-md-12 text-center">
+                <strong>
+                    Are you sure you want to delete this Product Example
+                    {{ product_example.prod_example_name }} - {{ product_example.product }}?
+                </strong>
+            </div>
+    </div>
+
+    <div class="row">
+        &nbsp;
+    </div>
+
+    <form action="
+            {%  url 'fpiweb:product_example_delete' pk=product_example.id %}"
+          method="POST">
+        {% csrf_token %}
+
+        <div class="row">
+            <div class="col-md-12 text-center">
+                <button id="delete_product_example"
+                        type="submit"
+                        class="btn btn-default alert-success">
+                    Confirm
+                </button>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-md-12 text-center">
+                <a class="btn alert-info"
+                   role="button"
+                   href="{% url 'fpiweb:product_example_view' %}">
+                    Cancel
+                </a>
+            </div>
+        </div>
+    </form>
+
+    <hr class="style-one">
+
+    <h6>
+        Template: product_example_delete.html
+    </h6>
+    <h6>
+        View: ProductExampleDelete
+    </h6>
+    <h6>
+        Delete URL: {%  url 'fpiweb:product_example_delete' pk=1 %}
+    </h6>
+    <h6>
+        Cancel URL: {% url 'fpiweb:product_example_view' %}
+    </h6>
+
+{% endblock %}

--- a/fpiweb/templates/fpiweb/product_example_delete.html
+++ b/fpiweb/templates/fpiweb/product_example_delete.html
@@ -42,17 +42,15 @@
         {% csrf_token %}
 
         <div class="row">
-            <div class="col-md-12 text-center">
+            <div class="col-md-6 text-center">
                 <button id="delete_product_example"
                         type="submit"
                         class="btn btn-default alert-success">
                     Confirm
                 </button>
             </div>
-        </div>
 
-        <div class="row">
-            <div class="col-md-12 text-center">
+            <div class="col-md-6 text-center">
                 <a class="btn alert-info"
                    role="button"
                    href="{% url 'fpiweb:product_example_view' %}">

--- a/fpiweb/templates/fpiweb/product_example_edit.html
+++ b/fpiweb/templates/fpiweb/product_example_edit.html
@@ -1,0 +1,65 @@
+{% extends 'fpiweb/base.html' %}
+{% load bootstrap4 %}
+
+{% block title %}
+    {% if product_example.id %}
+        Edit Product Example
+    (% else %}
+        Add Product Example
+    {% endif %}
+{% endblock %}
+
+{% block content %}
+    <div class="row">
+         <div class="col-md-12 text-center">
+            <h1 class="h1">
+                {% if product_example.id %}
+                    Edit Product Example
+                {% else %}
+                    Add Product Example
+                {% endif %}
+            </h1>
+         </div>
+     </div>
+
+    {% if form.non_field_errors %}
+        <div class="alert alert-danger">
+            <ul>
+                {% for error in form.non_field_errors %}
+                    <li>{{ error }}</li>
+                {% endfor %}
+            </ul>
+        </div>
+    {% endif %}
+
+    <form action="" method="post">
+        {% csrf_token %}
+        {% bootstrap_field form.prod_example_name %}
+        {% bootstrap_field form.product %}
+        <input type="submit" value="Submit"/>
+    </form>
+
+    <br/>
+    <a href="{% url 'fpiweb:product_example_view' %}">
+        Back to Product Example list
+    </a>
+
+    <hr class="style-one">
+
+    <h6>
+        Template: product_example_edit.html
+    </h6>
+    <h6>
+        View: ProductExampleCreateView and ProductExampleUpdateView
+    </h6>
+    <h6>
+        Add URL: {% url 'fpiweb:product_example_new' %}
+    </h6>
+    <h6>
+         Save URL: {% url 'fpiweb:product_example_view' %}
+    </h6>
+    <h6>
+        Return URL: {% url 'fpiweb:product_example_view' %}
+    </h6>
+
+{% endblock %}

--- a/fpiweb/templates/fpiweb/product_example_list.html
+++ b/fpiweb/templates/fpiweb/product_example_list.html
@@ -43,10 +43,13 @@
             <div class="col-md-3 text-center">
                 <strong>Edit this Product Name</strong>
             </div>
+            <div class="col-md-2 text-center">
+                <strong>Delete this row</strong>
+            </div>
         </div>
 
     {% if object_list %}
-        {% for prod_example_name in object_list %}
+        {% for product_example in object_list %}
             <div class="row text-center">
                 <div class="col-md-3">
                     {{ product_example.prod_example_name|safe }}
@@ -58,6 +61,16 @@
                            href="
                             {% url 'fpiweb:product_example_update' pk=product_example.id %}">
                             Edit
+                        </a>
+                    </div>
+                </div>
+                <div class="col-md-2">
+                    <div class="text-center">
+                        <a class="btn alert-info"
+                           role="button"
+                           href="
+                            {% url 'fpiweb:product_example_delete' pk=product_example.id %}">
+                            Delete
                         </a>
                     </div>
                 </div>

--- a/fpiweb/templates/fpiweb/product_example_list.html
+++ b/fpiweb/templates/fpiweb/product_example_list.html
@@ -88,8 +88,9 @@
 
         {% endfor %}
     {% else %}
-            </br>
+             <div class="alert-success">
             <p>No Product Examples are available. Click the Add Button above to create a Product Example.</p>
+             </div>
     {% endif %}
 
 

--- a/fpiweb/templates/fpiweb/product_example_list.html
+++ b/fpiweb/templates/fpiweb/product_example_list.html
@@ -6,7 +6,7 @@
 {# Table: ProductExample #}
 {# Form: ProductExampleForm #}
 
-{% block title %} Product Example {% endblock %}
+{% block title %} Product Example List{% endblock %}
 
 {% block content %}
     <div class="row">

--- a/fpiweb/templates/fpiweb/product_example_list.html
+++ b/fpiweb/templates/fpiweb/product_example_list.html
@@ -39,8 +39,9 @@
 
            <div class="row text-center">
             <div class="col-md-3"><strong>Product Name</strong></div>
-            <div class="col-md-4"><strong>Product Name ID</strong></div>
-            <div class="col-md-3 text-center">
+            <div class="col-md-5"><strong>Product Name ID</strong></div>
+
+            <div class="col-md-2 text-center">
                 <strong>Edit this Product Name</strong>
             </div>
             <div class="col-md-2 text-center">
@@ -50,10 +51,17 @@
 
     {% if object_list %}
         {% for product_example in object_list %}
-            <div class="row text-center">
+            <div class="row text-left">
                 <div class="col-md-3">
                     {{ product_example.prod_example_name|safe }}
                 </div>
+
+                <div class="col-md-5 text-left">
+                    {{ product_example.product }}
+                    <hr class="style-one"/>
+                </div>
+
+
                 <div class="col-md-2">
                     <div class="text-center">
                         <a class="btn alert-info"
@@ -64,6 +72,7 @@
                         </a>
                     </div>
                 </div>
+
                 <div class="col-md-2">
                     <div class="text-center">
                         <a class="btn alert-info"
@@ -74,20 +83,13 @@
                         </a>
                     </div>
                 </div>
+            </div>
 
-            </div>
-            <div class="row text-left">
-                <div class="col-md-1">
-                    &nbsp;
-                </div>
-                <div class="col-md-11">
-                    {{ product_example.product }}
-                    <hr class="style-one"/>
-                </div>
-            </div>
+
         {% endfor %}
     {% else %}
-        <p>No Product Examples are available.</p>
+            </br>
+            <p>No Product Examples are available. Click the Add Button above to create a Product Example.</p>
     {% endif %}
 
 

--- a/fpiweb/templates/fpiweb/product_example_list.html
+++ b/fpiweb/templates/fpiweb/product_example_list.html
@@ -1,0 +1,107 @@
+{% extends 'fpiweb/base.html' %}
+
+{# Purpose: List all Product Example rows #}
+{# URL Name: product_example_view #}
+{# URL Response: GET #}
+{# Table: ProductExample #}
+{# Form: ProductExampleForm #}
+
+{% block title %} Product Example {% endblock %}
+
+{% block content %}
+    <div class="row">
+        <div class="col-md-12 text-center">
+            <h1 class="h1">
+                Product Example List
+            </h1>
+        </div>
+    </div>
+
+    <hr class="style-one"/>
+
+    <div class="row">
+        &nbsp;
+    </div>
+
+    <div class="row">
+        <div class="col-md-12 text-center">
+            <a class="btn alert-info"
+               role="button"
+               href="{% url 'fpiweb:product_example_new' %}">
+                Add a Product Example
+            </a>
+        </div>
+    </div>
+
+     <div class="row">
+            &nbsp;
+        </div>
+
+           <div class="row text-center">
+            <div class="col-md-3"><strong>Product Name</strong></div>
+            <div class="col-md-4"><strong>Product Name ID</strong></div>
+            <div class="col-md-3 text-center">
+                <strong>Edit this Product Name</strong>
+            </div>
+        </div>
+
+    {% if object_list %}
+        {% for prod_example_name in object_list %}
+            <div class="row text-center">
+                <div class="col-md-3">
+                    {{ product_example.prod_example_name|safe }}
+                </div>
+                <div class="col-md-2">
+                    <div class="text-center">
+                        <a class="btn alert-info"
+                           role="button"
+                           href="
+                            {% url 'fpiweb:product_example_update' pk=product_example.id %}">
+                            Edit
+                        </a>
+                    </div>
+                </div>
+
+            </div>
+            <div class="row text-left">
+                <div class="col-md-1">
+                    &nbsp;
+                </div>
+                <div class="col-md-11">
+                    {{ product_example.product }}
+                    <hr class="style-one"/>
+                </div>
+            </div>
+        {% endfor %}
+    {% else %}
+        <p>No Product Examples are available.</p>
+    {% endif %}
+
+
+    <div class='row'>
+        <a href="{% url 'fpiweb:maintenance' %}">
+            Return to system maintenance
+        </a>
+    </div>
+
+    <hr class="style-one"/>
+
+    <h6>
+        Template: product_example_list.html
+    </h6>
+    <h6>
+        View: ProductExampleListView
+    </h6>
+    <h6>
+        Add URL: {% url 'fpiweb:product_example_new' %}
+    </h6>
+    <h6>
+        Edit URL: {% url 'fpiweb:product_example_update' pk=1 %}
+    </h6>
+     <h6>
+        Delete URL: {% url 'fpiweb:product_example_delete' pk=1 %}
+    </h6>
+
+
+
+{% endblock %}

--- a/fpiweb/templates/fpiweb/product_name_edit.html
+++ b/fpiweb/templates/fpiweb/product_name_edit.html
@@ -3,9 +3,9 @@
 
 {% block title %}
     {% if product_name.id %}
-        Edit Product Name
+        Edit Product
     (% else %}
-        Add Product Name
+        Add Product
     {% endif %}
 {% endblock %}
 
@@ -14,9 +14,9 @@
          <div class="col-md-12 text-center">
             <h1 class="h1">
                 {% if product_name.id %}
-                    Edit Product Name
+                    Edit Product
                 {% else %}
-                    Add Product Name
+                    Add Product
                 {% endif %}
             </h1>
          </div>
@@ -42,7 +42,7 @@
 
     <br/>
     <a href="{% url 'fpiweb:product_name_view' %}">
-        Back to Product Name list
+        Back to Product list
     </a>
 
     <hr class="style-one">

--- a/fpiweb/templates/fpiweb/product_name_edit.html
+++ b/fpiweb/templates/fpiweb/product_name_edit.html
@@ -1,0 +1,71 @@
+{% extends 'fpiweb/base.html' %}
+{% load bootstrap4 %}
+
+{% block title %}
+    {% if product_name.id %}
+        Edit Product Name
+    (% else %}
+        Add Product Name
+    {% endif %}
+{% endblock %}
+
+{% block content %}
+    <div class="row">
+         <div class="col-md-12 text-center">
+            <h1 class="h1">
+                {% if product_name.id %}
+                    Edit Product Name
+                {% else %}
+                    Add Product Name
+                {% endif %}
+            </h1>
+         </div>
+     </div>
+
+    {% if form.non_field_errors %}
+        <div class="alert alert-danger">
+            <ul>
+                {% for error in form.non_field_errors %}
+                    <li>{{ error }}</li>
+                {% endfor %}
+            </ul>
+        </div>
+    {% endif %}
+
+     <form action="" method="post">
+            {% csrf_token %}
+            {% bootstrap_field form.prod_name %}
+            {% bootstrap_field form.prod_cat %}
+            {# % bootstrap_form product_category_form % #}
+            <input type="submit" value="Submit"/>
+     </form>
+
+    <br/>
+    <a href="{% url 'fpiweb:product_name_view' %}">
+        Back to Product Name list
+    </a>
+
+    <hr class="style-one">
+
+    <h6>
+        Template: product_name_edit.html
+    </h6>
+    <h6>
+        View: ProductNameCreateView and ProductNameUpdateView
+    </h6>
+    <h6>
+        Add URL: {% url 'fpiweb:product_name_new' %}
+    </h6>
+    <h6>
+         Save URL: {% url 'fpiweb:product_name_view' %}
+    </h6>
+    <h6>
+        Return URL: {% url 'fpiweb:product_name_view' %}
+    </h6>
+
+
+
+
+
+
+{% endblock %}

--- a/fpiweb/templates/fpiweb/product_name_list.html
+++ b/fpiweb/templates/fpiweb/product_name_list.html
@@ -40,8 +40,8 @@
 
            <div class="row text-center">
             <div class="col-md-3"><strong>Product Name</strong></div>
-            <div class="col-md-4"><strong>Product Name ID</strong></div>
-            <div class="col-md-3 text-center">
+            <div class="col-md-7"><strong>Product Name ID</strong></div>
+            <div class="col-md-2 text-center">
                 <strong>Edit this Product Name</strong>
             </div>
         </div>
@@ -49,9 +49,16 @@
     {% if object_list %}
         {% for product_name in object_list %}
             <div class="row text-center">
-                <div class="col-md-3">
+                <div class="col-md-3 text-left">
                     {{ product_name.prod_name|safe }}
                 </div>
+
+                <div class="col-md-7 text-left">
+                    {{ product_name.prod_cat }}
+                    <hr class="style-one"/>
+                </div>
+
+
                 <div class="col-md-2">
                     <div class="text-center">
                         <a class="btn alert-info"
@@ -64,18 +71,10 @@
                 </div>
 
             </div>
-            <div class="row text-left">
-                <div class="col-md-1">
-                    &nbsp;
-                </div>
-                <div class="col-md-11">
-                    {{ product_name.prod_cat }}
-                    <hr class="style-one"/>
-                </div>
-            </div>
+
         {% endfor %}
     {% else %}
-        <p>No Product Categories are available.</p>
+        <p>No Product Categories are available. Click the Add Button above to add a Product Name.</p>
     {% endif %}
 
 

--- a/fpiweb/templates/fpiweb/product_name_list.html
+++ b/fpiweb/templates/fpiweb/product_name_list.html
@@ -1,18 +1,18 @@
 {% extends 'fpiweb/base.html' %}
 
-{# Purpose: List all Product Name rows #}
+{# Purpose: List all Product rows #}
 {# URL Name: product_name_view #}
 {# URL Response: GET #}
 {# Table: Product #}
 {# Form: ProductName #}
 
-{% block title %} Product Name Row {% endblock %}
+{% block title %} Product List {% endblock %}
 
 {% block content %}
     <div class="row">
         <div class="col-md-12 text-center">
             <h1 class="h1">
-                Product Name List
+                Product List
             </h1>
         </div>
     </div>
@@ -28,7 +28,7 @@
             <a class="btn alert-info"
                role="button"
                href="{% url 'fpiweb:product_name_new' %}">
-                Add a Product Name
+                Add a Product
             </a>
         </div>
     </div>
@@ -39,10 +39,10 @@
         </div>
 
            <div class="row text-center">
-            <div class="col-md-3"><strong>Product Name</strong></div>
-            <div class="col-md-7"><strong>Product Name ID</strong></div>
+            <div class="col-md-3"><strong>Product</strong></div>
+            <div class="col-md-7"><strong>Product ID</strong></div>
             <div class="col-md-2 text-center">
-                <strong>Edit this Product Name</strong>
+                <strong>Edit this Product </strong>
             </div>
         </div>
 
@@ -74,7 +74,9 @@
 
         {% endfor %}
     {% else %}
-        <p>No Product Categories are available. Click the Add Button above to add a Product Name.</p>
+        <div class="alert-success">
+            <p>No Products are available. Click the Add Button above to add a Product.</p>
+        </div>
     {% endif %}
 
 

--- a/fpiweb/templates/fpiweb/product_name_list.html
+++ b/fpiweb/templates/fpiweb/product_name_list.html
@@ -1,18 +1,18 @@
 {% extends 'fpiweb/base.html' %}
 
-{# Purpose: List all Product Category rows #}
-{# URL Name: product_category_view #}
+{# Purpose: List all Product Name rows #}
+{# URL Name: product_name_view #}
 {# URL Response: GET #}
-{# Table: ProductCategory #}
-{# Form: None #}
+{# Table: Product #}
+{# Form: ProductName #}
 
-{% block title %} Product Category Row {% endblock %}
+{% block title %} Product Name Row {% endblock %}
 
 {% block content %}
     <div class="row">
         <div class="col-md-12 text-center">
             <h1 class="h1">
-                Product Category List
+                Product Name List
             </h1>
         </div>
     </div>
@@ -27,36 +27,37 @@
         <div class="col-md-12 text-center">
             <a class="btn alert-info"
                role="button"
-               href="{% url 'fpiweb:product_category_new' %}">
-                Add a Product Category
+               href="{% url 'fpiweb:product_name_new' %}">
+                Add a Product Name
             </a>
         </div>
     </div>
 
-    <div class="row">
-        &nbsp;
-    </div>
 
-       <div class="row text-center">
-        <div class="col-md-3"><strong>Product Category</strong></div>
-{#        <div class="col-md-4"><strong>Description</strong></div>#}
-        <div class="col-md-3 text-center">
-            <strong>Edit this Product Category</strong>
+    <div class="row">
+            &nbsp;
         </div>
-    </div>
+
+           <div class="row text-center">
+            <div class="col-md-3"><strong>Product Name</strong></div>
+            <div class="col-md-4"><strong>Product Name ID</strong></div>
+            <div class="col-md-3 text-center">
+                <strong>Edit this Product Name</strong>
+            </div>
+        </div>
 
     {% if object_list %}
-        {% for product_category in object_list %}
+        {% for product_name in object_list %}
             <div class="row text-center">
                 <div class="col-md-3">
-                    {{ product_category.prod_cat_name|safe }}
+                    {{ product_name.prod_name|safe }}
                 </div>
                 <div class="col-md-2">
                     <div class="text-center">
                         <a class="btn alert-info"
                            role="button"
                            href="
-                            {% url 'fpiweb:product_category_update' pk=product_category.id %}">
+                            {% url 'fpiweb:product_name_update' pk=product_name.id %}">
                             Edit
                         </a>
                     </div>
@@ -68,7 +69,7 @@
                     &nbsp;
                 </div>
                 <div class="col-md-11">
-                    {{ product_category.prod_cat_descr }}
+                    {{ product_name.prod_cat }}
                     <hr class="style-one"/>
                 </div>
             </div>
@@ -76,6 +77,10 @@
     {% else %}
         <p>No Product Categories are available.</p>
     {% endif %}
+
+
+
+
     <div class='row'>
         <a href="{% url 'fpiweb:maintenance' %}">
             Return to system maintenance
@@ -85,18 +90,17 @@
     <hr class="style-one"/>
 
     <h6>
-        Template: product_category_list.html
+        Template: product_name_list.html
     </h6>
     <h6>
-        View: ProductCategoryListView
+        View: ProductNameListView
     </h6>
     <h6>
-        Add URL: {% url 'fpiweb:product_category_new' %}
+        Add URL: {% url 'fpiweb:product_name_new' %}
     </h6>
     <h6>
-        Edit URL: {% url 'fpiweb:product_category_update' pk=1 %}
+        Edit URL: {% url 'fpiweb:product_name_update' pk=1 %}
     </h6>
 
 
 {% endblock %}
-

--- a/fpiweb/templates/fpiweb/system_maintenance.html
+++ b/fpiweb/templates/fpiweb/system_maintenance.html
@@ -33,7 +33,7 @@
     </a>
 
     <br/>
-    <a href="{% url 'fpiweb:about' %}">
+    <a href="{% url 'fpiweb:product_example_view' %}">
         Product Example Maintenance
     </a>
 

--- a/fpiweb/templates/fpiweb/system_maintenance.html
+++ b/fpiweb/templates/fpiweb/system_maintenance.html
@@ -28,7 +28,7 @@
     </a>
 
     <br/>
-    <a href="{% url 'fpiweb:about' %}">
+    <a href="{% url 'fpiweb:product_name_view' %}">
         Product Name Maintenance
     </a>
 

--- a/fpiweb/templates/fpiweb/system_maintenance.html
+++ b/fpiweb/templates/fpiweb/system_maintenance.html
@@ -23,18 +23,18 @@
     <h6>Manage Product Information</h6>
 
     <br/>
-    <a href="{% url 'fpiweb:about' %}">
-        Product Category Maintainence
+    <a href="{% url 'fpiweb:product_category_view' %}">
+        Product Category Maintenance
     </a>
 
     <br/>
     <a href="{% url 'fpiweb:about' %}">
-        Product Name Maintainence
+        Product Name Maintenance
     </a>
 
     <br/>
     <a href="{% url 'fpiweb:about' %}">
-        Product Example Maintainence
+        Product Example Maintennance
     </a>
 
     <hr/>

--- a/fpiweb/templates/fpiweb/system_maintenance.html
+++ b/fpiweb/templates/fpiweb/system_maintenance.html
@@ -15,7 +15,7 @@
 
     <div>
         <a href="{% url 'fpiweb:user_management' %}">
-            System User Maintainance
+            System User Maintennance
         </a>
     </div>
 
@@ -34,7 +34,7 @@
 
     <br/>
     <a href="{% url 'fpiweb:about' %}">
-        Product Example Maintennance
+        Product Example Maintenance
     </a>
 
     <hr/>
@@ -42,17 +42,17 @@
 
     <br/>
     <a href="{% url 'fpiweb:loc_row_view' %}">
-        Location Row Maintainence
+        Location Row Maintenance
     </a>
 
     <br/>
     <a href="{% url 'fpiweb:loc_bin_view' %}">
-        Location Bin Maintainence
+        Location Bin Maintenance
     </a>
 
     <br/>
     <a href="{% url 'fpiweb:loc_tier_view' %}">
-        Location Tier Maintainence
+        Location Tier Maintenance
     </a>
 
     <br/>

--- a/fpiweb/templates/fpiweb/system_maintenance.html
+++ b/fpiweb/templates/fpiweb/system_maintenance.html
@@ -29,7 +29,7 @@
 
     <br/>
     <a href="{% url 'fpiweb:product_name_view' %}">
-        Product Name Maintenance
+        Product Maintenance
     </a>
 
     <br/>

--- a/fpiweb/urls.py
+++ b/fpiweb/urls.py
@@ -52,7 +52,8 @@ from fpiweb.views import \
     TestScanView, \
     UserManagementView, \
     UserCreateview, \
-    UserUpdateView, ProductCategoryListView, ProductCategoryUpdateView
+    UserUpdateView, ProductCategoryListView, ProductCategoryUpdateView, ProductNameListView, ProductNameCreateView, \
+    ProductNameUpdateView
 
 __author__ = '(Multiple)'
 __project__ = "Food-Pantry-Inventory"
@@ -321,6 +322,21 @@ urlpatterns = [
     # e.g. /fpiweb/product_category/edit/4/ = edit product_category # 4
     path('product_category/edit/<int:pk>/', ProductCategoryUpdateView.as_view(),
          name='product_category_update' ),
+
+    # Product List page
+    # e.g. /fpiweb/product/ = list of product
+    path('product_name/', ProductNameListView.as_view(),
+         name='product_name_view'),
+
+    # ProductCategory Add page
+    # e.g. /fpiweb/product_/add/ = add a product
+    path('product_name/add/', ProductNameCreateView.as_view(),
+         name='product_name_new' ),
+
+    # Product Edit page
+    # e.g. /fpiweb/product/edit/4/ = edit product # 4
+    path('product_name/edit/<int:pk>/', ProductNameUpdateView.as_view(),
+         name='product_name_update' ),
 
 
 

--- a/fpiweb/urls.py
+++ b/fpiweb/urls.py
@@ -53,7 +53,8 @@ from fpiweb.views import \
     UserManagementView, \
     UserCreateview, \
     UserUpdateView, ProductCategoryListView, ProductCategoryUpdateView, ProductNameListView, ProductNameCreateView, \
-    ProductNameUpdateView
+    ProductNameUpdateView, ProductExampleUpdateView, ProductExampleCreateView, ProductExampleDeleteView, \
+    ProductExampleListView
 
 __author__ = '(Multiple)'
 __project__ = "Food-Pantry-Inventory"
@@ -337,6 +338,27 @@ urlpatterns = [
     # e.g. /fpiweb/product/edit/4/ = edit product # 4
     path('product_name/edit/<int:pk>/', ProductNameUpdateView.as_view(),
          name='product_name_update' ),
+
+    # ProductExample List page
+    # e.g. /fpiweb/product_example/ = list of product examples
+    path('product_example/', ProductExampleListView.as_view(),
+         name='product_example_view'),
+
+    # PrdductExample Add page
+    # e.g. /fpiweb/product_example/add/ = add a product example
+    path('product_example/add/', ProductExampleCreateView.as_view(),
+         name='product_example_new', ),
+
+    # ProductExample Edit page
+    # e.g. /fpiweb/product_example/edit/4/ = edit product example # 4
+    path('product_example/edit/<int:pk>/', ProductExampleUpdateView.as_view(),
+         name='product_example_update', ),
+
+    # ProductExample Delete Page
+    # e.g. /fpiweb/product_example/delete/4/ = delete product_example # 4
+    path('product_example/delete/<int:pk>/', ProductExampleDeleteView.as_view(),
+         name='product_example_delete', ),
+
 
 
 

--- a/fpiweb/urls.py
+++ b/fpiweb/urls.py
@@ -52,8 +52,15 @@ from fpiweb.views import \
     TestScanView, \
     UserManagementView, \
     UserCreateview, \
-    UserUpdateView, ProductCategoryListView, ProductCategoryUpdateView, ProductNameListView, ProductNameCreateView, \
-    ProductNameUpdateView, ProductExampleUpdateView, ProductExampleCreateView, ProductExampleDeleteView, \
+    UserUpdateView, \
+    ProductCategoryListView, \
+    ProductCategoryUpdateView, \
+    ProductNameListView, \
+    ProductNameCreateView, \
+    ProductNameUpdateView, \
+    ProductExampleUpdateView, \
+    ProductExampleCreateView, \
+    ProductExampleDeleteView, \
     ProductExampleListView
 
 __author__ = '(Multiple)'

--- a/fpiweb/urls.py
+++ b/fpiweb/urls.py
@@ -48,10 +48,11 @@ from fpiweb.views import \
     ManualNewBoxView, \
     ManualPalletMoveView, \
     PrintLabelsView, \
+    ProductCategoryCreateView, \
     TestScanView, \
     UserManagementView, \
     UserCreateview, \
-    UserUpdateView
+    UserUpdateView, ProductCategoryListView, ProductCategoryUpdateView
 
 __author__ = '(Multiple)'
 __project__ = "Food-Pantry-Inventory"
@@ -305,6 +306,23 @@ urlpatterns = [
     # e.g. /fpiweb/user_mgmt/edit/5/ = update an existing user
     path('user_mgmt/edit/<int:pk>', UserUpdateView.as_view(),
          name='user_edit'),
+
+    # ProductCategory List page
+    # e.g. /fpiweb/product_category/ = list of product_category
+    path('product_category/', ProductCategoryListView.as_view(),
+         name='product_category_view'),
+
+    # ProductCategory Add page
+    # e.g. /fpiweb/product_category/add/ = add a product_category
+    path('product_category/add/', ProductCategoryCreateView.as_view(),
+         name='product_category_new' ),
+
+    # ProductCategory Edit page
+    # e.g. /fpiweb/product_category/edit/4/ = edit product_category # 4
+    path('product_category/edit/<int:pk>/', ProductCategoryUpdateView.as_view(),
+         name='product_category_update' ),
+
+
 
 ]
 

--- a/fpiweb/views.py
+++ b/fpiweb/views.py
@@ -77,7 +77,7 @@ from fpiweb.models import \
     Product, \
     Profile, \
     Location, \
-    PalletBox, ProductCategory
+    PalletBox, ProductCategory, ProductExample
 from fpiweb.code_reader import \
     CodeReaderError, \
     read_box_number
@@ -112,7 +112,7 @@ from fpiweb.forms import \
     validation_exp_months_bool, \
     UserInfoForm, \
     UserInfoModes as MODES, \
-    ChangePasswordForm, ProductCategoryForm, ProductNameForm
+    ChangePasswordForm, ProductCategoryForm, ProductNameForm, ProductExampleForm
 from fpiweb.qr_code_utilities import QRCodePrinter
 from fpiweb.support.BoxManagement import BoxManagementClass
 from fpiweb.support.PermissionsManagement import ManageUserPermissions
@@ -3178,6 +3178,85 @@ class ProductNameUpdateView(PermissionRequiredMixin, UpdateView):
     context_object_name = 'product_name'
     form_class = ProductNameForm
     success_url = reverse_lazy('fpiweb:product_name_view')
+
+
+class ProductExampleListView(PermissionRequiredMixin, ListView):
+    """
+    List of existing Product Examples using a generic ListView.
+    """
+
+    permission_required = (
+        'fpiweb.view_product_example',
+    )
+
+    model = ProductExample
+    template_name = 'fpiweb/product_example_list.html'
+    context_object_name = 'product_example_list_content'
+
+
+class ProductExampleCreateView(PermissionRequiredMixin, CreateView):
+    """
+    Create a Product Example using a generic CreateView.
+    """
+
+    permission_required = (
+        'fpiweb.add_product_example',
+    )
+
+    model = ProductExample
+    template_name = 'fpiweb/product_example_edit.html'
+    context_object_name = 'product_example'
+    success_url = reverse_lazy('fpiweb:product_example_view')
+
+    formClass = ProductExampleForm
+
+    fields = ['prod_example_name', 'product', ]
+
+
+class ProductExampleUpdateView(PermissionRequiredMixin, UpdateView):
+    """
+    Update a Product Example using a generic UpdateView.
+    """
+
+    permission_required = (
+        'fpiweb.change_product_example_name',
+    )
+
+    model = ProductExample
+    template_name = 'fpiweb/product_example_edit.html'
+    context_object_name = 'product_example'
+    form_class = ProductExampleForm
+    success_url = reverse_lazy('fpiweb:product_exampple_view')
+
+
+class ProductExampleDeleteView(PermissionRequiredMixin, DeleteView):
+    """
+    Delete a Product Example using a generic DeleteView.
+    """
+
+    permission_required = (
+        'fpiweb.delete_product_example_name',
+    )
+
+    model = ProductExample
+    template_name = 'fpiweb/product_example_delete.html'
+    context_object_name = 'loc_row'
+    success_url = reverse_lazy('fpiweb:product_example_view')
+
+    form_class = ProductExampleForm
+
+    def get_context_data(self, **kwargs):
+        """
+        Modify the context before rendering the template.
+
+        :param kwargs:
+        :return:
+        """
+
+        context = super(ProductExampleDeleteView, self).get_context_data(**kwargs)
+        context['action'] = reverse('fpiweb:product_example_delete',
+                                    kwargs={'pk': self.get_object().id})
+        return context
 
 
 

--- a/fpiweb/views.py
+++ b/fpiweb/views.py
@@ -77,7 +77,7 @@ from fpiweb.models import \
     Product, \
     Profile, \
     Location, \
-    PalletBox
+    PalletBox, ProductCategory
 from fpiweb.code_reader import \
     CodeReaderError, \
     read_box_number
@@ -112,7 +112,7 @@ from fpiweb.forms import \
     validation_exp_months_bool, \
     UserInfoForm, \
     UserInfoModes as MODES, \
-    ChangePasswordForm
+    ChangePasswordForm, ProductCategoryForm
 from fpiweb.qr_code_utilities import QRCodePrinter
 from fpiweb.support.BoxManagement import BoxManagementClass
 from fpiweb.support.PermissionsManagement import ManageUserPermissions
@@ -3076,6 +3076,58 @@ class UserUpdateView(PermissionRequiredMixin, View):
                 target_user=target_user,
             )
             return render(request, self.template_name, post_context)
+
+
+class ProductCategoryCreateView(PermissionRequiredMixin, CreateView):
+    """
+    Create a Product Category using a generic CreateView.
+    """
+
+    # Mike Rehner adding a permission here but its not set up elsewhere
+    permission_required = (
+        'fpiweb.add_product_category',
+    )
+
+    model = ProductCategory
+    template_name = 'fpiweb/product_category_edit.html'
+    context_object_name = 'product_category'
+    success_url = reverse_lazy('fpiweb:product_category_view')
+
+    formClass = ProductCategoryForm
+
+    fields = ['prod_cat_name', 'prod_cat_descr', ]
+
+class ProductCategoryListView(PermissionRequiredMixin, ListView):
+    """
+    List of existing rows using a generic ListView.
+    """
+
+    # by Mike Rehner- not sure how permission set up
+    permission_required = (
+        'fpiweb.view_product_category',
+    )
+
+    model = ProductCategory
+    template_name = 'fpiweb/product_category_list.html'
+    context_object_name = 'product_category_list_content'
+
+
+class ProductCategoryUpdateView(PermissionRequiredMixin, UpdateView):
+    """
+    Update a Product Category using a generic UpdateView.
+    """
+
+    # by Mike Rehner- not sure how permission set up
+    permission_required = (
+        'fpiweb.change_product_category',
+    )
+
+    model = ProductCategory
+    template_name = 'fpiweb/product_category_edit.html'
+    context_object_name = 'product_category'
+    form_class = LocRowForm
+    success_url = reverse_lazy('fpiweb:product_category_view')
+
 
 
 # class ManualNotification(LoginRequiredMixin, TemplateView):

--- a/fpiweb/views.py
+++ b/fpiweb/views.py
@@ -3083,7 +3083,7 @@ class ProductCategoryCreateView(PermissionRequiredMixin, CreateView):
     Create a Product Category using a generic CreateView.
     """
 
-    # Mike Rehner adding a permission here but its not set up elsewhere
+    # by Mike Rehner adding permission but not sure how its granted
     permission_required = (
         'fpiweb.add_product_category',
     )
@@ -3099,10 +3099,10 @@ class ProductCategoryCreateView(PermissionRequiredMixin, CreateView):
 
 class ProductCategoryListView(PermissionRequiredMixin, ListView):
     """
-    List of existing rows using a generic ListView.
+    List of existing Product Categories using a generic ListView.
     """
 
-    # by Mike Rehner- not sure how permission set up
+    # by Mike Rehner adding permission but not sure how its granted
     permission_required = (
         'fpiweb.view_product_category',
     )
@@ -3117,7 +3117,7 @@ class ProductCategoryUpdateView(PermissionRequiredMixin, UpdateView):
     Update a Product Category using a generic UpdateView.
     """
 
-    # by Mike Rehner- not sure how permission set up
+    # by Mike Rehner adding permission but not sure how its granted
     permission_required = (
         'fpiweb.change_product_category',
     )
@@ -3131,10 +3131,10 @@ class ProductCategoryUpdateView(PermissionRequiredMixin, UpdateView):
 
 class ProductNameCreateView(PermissionRequiredMixin, CreateView):
     """
-    Create a Product Category using a generic CreateView.
+    Create a Product using a generic CreateView.
     """
 
-    # Mike Rehner adding a permission here but its not set up elsewhere
+    # by Mike Rehner adding permission but not sure how its granted
     permission_required = (
         'fpiweb.add_product_name',
     )
@@ -3150,10 +3150,10 @@ class ProductNameCreateView(PermissionRequiredMixin, CreateView):
 
 class ProductNameListView(PermissionRequiredMixin, ListView):
     """
-    List of existing rows using a generic ListView.
+    List of Products using a generic ListView.
     """
 
-    # by Mike Rehner- not sure how permission set up
+    # by Mike Rehner adding permission but not sure how its granted
     permission_required = (
         'fpiweb.view_product_name',
     )
@@ -3165,10 +3165,10 @@ class ProductNameListView(PermissionRequiredMixin, ListView):
 
 class ProductNameUpdateView(PermissionRequiredMixin, UpdateView):
     """
-    Update a Product Category using a generic UpdateView.
+    Update a Product using a generic UpdateView.
     """
 
-    # by Mike Rehner- not sure how permission set up
+    # by Mike Rehner adding permission but not sure how its granted
     permission_required = (
         'fpiweb.change_product_name',
     )
@@ -3185,6 +3185,7 @@ class ProductExampleListView(PermissionRequiredMixin, ListView):
     List of existing Product Examples using a generic ListView.
     """
 
+    # by Mike Rehner adding permission but not sure how its granted
     permission_required = (
         'fpiweb.view_product_example',
     )
@@ -3199,6 +3200,7 @@ class ProductExampleCreateView(PermissionRequiredMixin, CreateView):
     Create a Product Example using a generic CreateView.
     """
 
+    # by Mike Rehner adding permission but not sure how its granted
     permission_required = (
         'fpiweb.add_product_example',
     )
@@ -3218,6 +3220,7 @@ class ProductExampleUpdateView(PermissionRequiredMixin, UpdateView):
     Update a Product Example using a generic UpdateView.
     """
 
+    # by Mike Rehner adding permission but not sure how its granted
     permission_required = (
         'fpiweb.change_product_example_name',
     )
@@ -3234,6 +3237,7 @@ class ProductExampleDeleteView(PermissionRequiredMixin, DeleteView):
     Delete a Product Example using a generic DeleteView.
     """
 
+    # by Mike Rehner adding permission but not sure how its granted
     permission_required = (
         'fpiweb.delete_product_example_name',
     )

--- a/fpiweb/views.py
+++ b/fpiweb/views.py
@@ -112,7 +112,7 @@ from fpiweb.forms import \
     validation_exp_months_bool, \
     UserInfoForm, \
     UserInfoModes as MODES, \
-    ChangePasswordForm, ProductCategoryForm
+    ChangePasswordForm, ProductCategoryForm, ProductNameForm
 from fpiweb.qr_code_utilities import QRCodePrinter
 from fpiweb.support.BoxManagement import BoxManagementClass
 from fpiweb.support.PermissionsManagement import ManageUserPermissions
@@ -3127,6 +3127,57 @@ class ProductCategoryUpdateView(PermissionRequiredMixin, UpdateView):
     context_object_name = 'product_category'
     form_class = ProductCategoryForm
     success_url = reverse_lazy('fpiweb:product_category_view')
+
+
+class ProductNameCreateView(PermissionRequiredMixin, CreateView):
+    """
+    Create a Product Category using a generic CreateView.
+    """
+
+    # Mike Rehner adding a permission here but its not set up elsewhere
+    permission_required = (
+        'fpiweb.add_product_name',
+    )
+
+    model = Product
+    template_name = 'fpiweb/product_name_edit.html'
+    context_object_name = 'product_name'
+    success_url = reverse_lazy('fpiweb:product_name_view')
+
+    formClass = ProductNameForm
+
+    fields = ['prod_name', 'prod_cat', ]
+
+class ProductNameListView(PermissionRequiredMixin, ListView):
+    """
+    List of existing rows using a generic ListView.
+    """
+
+    # by Mike Rehner- not sure how permission set up
+    permission_required = (
+        'fpiweb.view_product_name',
+    )
+
+    model = Product
+    template_name = 'fpiweb/product_name_list.html'
+    context_object_name = 'product_name_list_content'
+
+
+class ProductNameUpdateView(PermissionRequiredMixin, UpdateView):
+    """
+    Update a Product Category using a generic UpdateView.
+    """
+
+    # by Mike Rehner- not sure how permission set up
+    permission_required = (
+        'fpiweb.change_product_name',
+    )
+
+    model = Product
+    template_name = 'fpiweb/product_name_edit.html'
+    context_object_name = 'product_name'
+    form_class = ProductNameForm
+    success_url = reverse_lazy('fpiweb:product_name_view')
 
 
 

--- a/fpiweb/views.py
+++ b/fpiweb/views.py
@@ -77,7 +77,9 @@ from fpiweb.models import \
     Product, \
     Profile, \
     Location, \
-    PalletBox, ProductCategory, ProductExample
+    PalletBox, \
+    ProductCategory, \
+    ProductExample
 from fpiweb.code_reader import \
     CodeReaderError, \
     read_box_number
@@ -112,7 +114,10 @@ from fpiweb.forms import \
     validation_exp_months_bool, \
     UserInfoForm, \
     UserInfoModes as MODES, \
-    ChangePasswordForm, ProductCategoryForm, ProductNameForm, ProductExampleForm
+    ChangePasswordForm, \
+    ProductCategoryForm, \
+    ProductNameForm, \
+    ProductExampleForm
 from fpiweb.qr_code_utilities import QRCodePrinter
 from fpiweb.support.BoxManagement import BoxManagementClass
 from fpiweb.support.PermissionsManagement import ManageUserPermissions

--- a/fpiweb/views.py
+++ b/fpiweb/views.py
@@ -3226,7 +3226,7 @@ class ProductExampleUpdateView(PermissionRequiredMixin, UpdateView):
     template_name = 'fpiweb/product_example_edit.html'
     context_object_name = 'product_example'
     form_class = ProductExampleForm
-    success_url = reverse_lazy('fpiweb:product_exampple_view')
+    success_url = reverse_lazy('fpiweb:product_example_view')
 
 
 class ProductExampleDeleteView(PermissionRequiredMixin, DeleteView):
@@ -3240,7 +3240,7 @@ class ProductExampleDeleteView(PermissionRequiredMixin, DeleteView):
 
     model = ProductExample
     template_name = 'fpiweb/product_example_delete.html'
-    context_object_name = 'loc_row'
+    context_object_name = 'product_example'
     success_url = reverse_lazy('fpiweb:product_example_view')
 
     form_class = ProductExampleForm

--- a/fpiweb/views.py
+++ b/fpiweb/views.py
@@ -3125,7 +3125,7 @@ class ProductCategoryUpdateView(PermissionRequiredMixin, UpdateView):
     model = ProductCategory
     template_name = 'fpiweb/product_category_edit.html'
     context_object_name = 'product_category'
-    form_class = LocRowForm
+    form_class = ProductCategoryForm
     success_url = reverse_lazy('fpiweb:product_category_view')
 
 


### PR DESCRIPTION
Rebased with upstream/dev version pulled down from WARM 9/26/20. Added 'ProductCategory', 'Product', and 'Product Example'pages. Also changed import statements so that each separate import is on a single line. Disregard '05ProductCategory' pull request!