### PR TITLE
Specify for Read the Docs to use Python3.8 instead of 3.7

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,13 @@
 # Required (Specifies using v2 of Read the Docs configuration format)
 version: 2
 
+# Optionally build your docs in additional formats such as PDF
+formats:
+  - epub
+  - htmlzip
+  - pdf
+
+# Optionally set the version of Python and requirements required to build your docs
 python:
   version: 3.8
   install:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,3 +7,5 @@ version: 2
 
 python:
   version: 3.8
+  install:
+    - requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,9 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required (Specifies using v2 of Read the Docs configuration format)
+version: 2
+
+python:
+  version: 3.8

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,4 +8,4 @@ version: 2
 python:
   version: 3.8
   install:
-    - requirements.txt
+    - requirements: requirements.txt


### PR DESCRIPTION
Configuration file options should build the documentation using python3.8, with the same options as we had before (i.e. PDF and EPUB downloadables).

I tried keeping the config file minimal.