### PR TITLE
10 install django debug toolbar

### DIFF
--- a/FPIDjango/settings.py
+++ b/FPIDjango/settings.py
@@ -96,6 +96,8 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+
+
 ]
 
 ROOT_URLCONF = 'FPIDjango.urls'
@@ -355,3 +357,15 @@ LOGGING = {
         'handlers': ['file', 'console'],
     },
 }
+
+# Sets up django-debug-toolbar in browser
+# If toolbar disappears after adding an installed app  or middleware
+# there might be a problem in the ordering of INSTALLED_APPS or MIDDLEWARE
+if DEBUG:
+    INSTALLED_APPS = INSTALLED_APPS + [
+        # django debug toolbar not on main stream
+        'debug_toolbar'
+    ]
+    MIDDLEWARE = MIDDLEWARE + [
+        'debug_toolbar.middleware.DebugToolbarMiddleware',
+    ]

--- a/FPIDjango/urls.py
+++ b/FPIDjango/urls.py
@@ -21,17 +21,12 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import include, path
 
-from fpiweb.views import \
-    LoginView
-
-import debug_toolbar
+from fpiweb.views import LoginView
 
 
 __author__ = '(Multiple)'
 __project__ = "Food-Pantry-Inventory"
 __creation_date__ = "04/01/2019"
-
-
 
 
 

--- a/FPIDjango/urls.py
+++ b/FPIDjango/urls.py
@@ -24,15 +24,32 @@ from django.urls import include, path
 from fpiweb.views import \
     LoginView
 
+import debug_toolbar
+
 
 __author__ = '(Multiple)'
 __project__ = "Food-Pantry-Inventory"
 __creation_date__ = "04/01/2019"
 
+
+
+
+
 urlpatterns = [
+
     path('', LoginView.as_view()),
     path('fpiweb/', include('fpiweb.urls')),
     path('warmadmin/', admin.site.urls,),
+
 ]
+
+# required for django-debug-toolbar
+from .settings import DEBUG
+if DEBUG:
+    import debug_toolbar
+    urlpatterns = [
+        path('__debug__/', include(debug_toolbar.urls)),
+    ] + urlpatterns
+
 
 # EOF

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ dateparser==1.0.0
 Django==3.1.4
 django-bootstrap4==2.3.1
 django-db==0.0.7
-django-debug-toolbar-django13==0.8.4
+django-debug-toolbar==3.2
 django-extensions==3.1.0
 docopt==0.6.2
 docutils==0.16


### PR DESCRIPTION
Installed a newer version of the django-debug-toolbar. Removed old version. Verified it works. Wrapped django-debug-toolbar code in if DEBUG true statements. Used directions from https://django-debug-toolbar.readthedocs.io/en/latest/ and https://learnwagtail.com/tutorials/installing-django-debug-toolbar/